### PR TITLE
Downgrade the plugin to version 2.3.3 and Gradle to 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # acc
-A short term test repo for addressing an Android aggregate code coverage (acc) issue.
+A short term test repo for addressing an Android aggregate code coverage (acc) issue whereby separately generated JVM (unit) test results cannot be combined with instrumentation (connected test) data.
+
+Build instructions:
+
+    ./gradlew clean jacocoTestReport
+
+With the Android Gradle plugin version 2.3.3 and Gradle 3.3, no errors occur and the generated report does contain the expected result! Nice.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
+apply from: 'jacoco.gradle'
 
 android {
     compileSdkVersion 26
@@ -16,21 +15,28 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            // Enable connected checks on the debug build variant.
+            testCoverageEnabled = true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    testOptions {
+        unitTests.all {}
+    }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.android.support:design:26.1.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support:design:26.1.0'
+    testCompile 'junit:junit:4.12'
+    androidTestCompile('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/app/jacoco.gradle
+++ b/app/jacoco.gradle
@@ -1,0 +1,38 @@
+apply plugin: 'jacoco'
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = [
+            '**/R.class',
+            '**/R$*.class',
+            '**/BuildConfig.*',
+            '**/Manifest*.*',
+            '**/*Test*.*',
+            'android/**/*.*'
+    ]
+
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+
+    // Generate new names for the *.ec files that has no spaces. NOTE this is apparently not working as intended.
+    /*
+    def ecTree = fileTree(dir: project.buildDir, includes: ["outputs/code-coverage/connected/*coverage.ec"])
+    ecTree.each {File file ->
+        def newName = file.name.replaceAll(" ", "_")
+        def newFile = new File(file.getParent(), newName)
+        def result = file.renameTo(newFile);
+        project.logger.lifecycle "Renamed file {" + file.path + "} to {" + newFile.path + "}"
+    }
+    */
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            "jacoco/testDebugUnitTest.exec", "outputs/code-coverage/connected/*coverage.ec"
+    ])
+}

--- a/app/src/androidTest/java/com/pajato/acc/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/pajato/acc/ExampleInstrumentedTest.kt
@@ -1,8 +1,15 @@
 package com.pajato.acc
 
 import android.support.test.InstrumentationRegistry
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -15,10 +22,18 @@ import org.junit.Assert.*
  */
 @RunWith(AndroidJUnit4::class)
 class ExampleInstrumentedTest {
-    @Test
-    fun useAppContext() {
+    /** Define the component under test using a JUnit rule. */
+    @Rule @JvmField var activityRule = ActivityTestRule<MainActivity>(MainActivity::class.java)
+
+    /** Nop test provided by AS. */
+    @Test fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getTargetContext()
         assertEquals("com.pajato.acc", appContext.packageName)
+    }
+
+    /** Check that the initial display shows the main activity view. */
+    @Test fun testInitialState() {
+        onView(withId(R.id.helloWorldText)).check(matches(withEffectiveVisibility(VISIBLE)))
     }
 }

--- a/app/src/main/java/com/pajato/acc/MainActivity.kt
+++ b/app/src/main/java/com/pajato/acc/MainActivity.kt
@@ -10,6 +10,11 @@ import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
+    /** Provide a static function to be JVM tested (off device) */
+    companion object {
+        fun add(arg1: Int, arg2: Int) = arg1 + arg2
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -8,7 +8,7 @@
     tools:context="com.pajato.acc.MainActivity"
     tools:showIn="@layout/activity_main">
 
-    <TextView
+    <TextView android:id="@+id/helloWorldText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"

--- a/app/src/test/java/com/pajato/acc/ExampleUnitTest.kt
+++ b/app/src/test/java/com/pajato/acc/ExampleUnitTest.kt
@@ -10,8 +10,8 @@ import org.junit.Assert.*
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 class ExampleUnitTest {
-    @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    @Test fun testMainAcivityAdd() {
+        val actual = MainActivity.add(2, 2)
+        assertEquals(4, actual)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
     ext.kotlin_version = '1.1.51'
     repositories {
-        google()
+        maven { url "https://maven.google.com" }
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -17,7 +17,7 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
+        maven { url "https://maven.google.com" }
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit reverts the project to the current stable Android Gradle plugin version 2.3.3 and Gradle to version 3.3 (via the wrapper).  Doing so shows that under the stable release, the technique recommended by the blog post at https://medium.com/@rafael_toledo/setting-up-an-unified-coverage-report-in-android-with-jacoco-robolectric-and-espresso-ffe239aaf3fa works using Kotlin.  To illustrate a working test, code has been added in the main activity and suitable tests added.

<h1>File changes:</h1>

modified:   README.md

- Summary: Document the initial (baseline) work.

modified:   app/build.gradle

- Summary: apply the Jacoco task via the separate Jacoco build file; enable connected and unit test coverage; revert to the old style "compile" keyword for dependencies.

new file:   app/jacoco.gradle

- Summary: new file to provide the coverage merging task.

modified:   app/src/androidTest/java/com/pajato/acc/ExampleInstrumentedTest.kt

- acivityRule: new variable to specify the main activity as the activity under test.
- testInitialState(): ensure that the hello world text view is visible so that there is some connected check coverage data.

modified:   app/src/main/java/com/pajato/acc/MainActivity.kt

- add(): provide a static and simple function to provide unit test coverage data.

modified:   app/src/main/res/layout/content_main.xml

- Summary: specify an id for the hello world text view.

modified:   app/src/test/java/com/pajato/acc/ExampleUnitTest.kt

- addition_isCorrect(): morph to testMainActivityAdd().

modified:   build.gradle

- Summary: revert to old-style spec for Google Maven repo; downgrade to the stable 2.3.3 plugin version.

modified:   gradle/wrapper/gradle-wrapper.properties

- Summary: revert to Gradle 3.3