### PR TITLE
Upgrade to version 3.0.0-rc1 of the Android Gradle Plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,52 @@ Build instructions:
     ./gradlew clean jacocoTestReport
 
 With the Android Gradle plugin version 2.3.3 and Gradle 3.3, no errors occur and the generated report does contain the expected result! Nice.
+
+When using the Android Gradle plugin version 3.0.0-rc1 with Gradle 4.1, two errors occurred.  The first:
+
+    ...
+    :app:testDebugUnitTest
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.agent/0.7.8/org.jacoco.agent-0.7.8.pom
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.build/0.7.8/org.jacoco.build-0.7.8.pom
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.agent/0.7.8/org.jacoco.agent-0.7.8.jar
+    objc[15619]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/bin/java (0x10442a4c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x1044b64e0). One of the two will be used. Which one is undefined.
+    Error occurred during initialization of VM
+    java.lang.InternalError: Could not create SecurityManager: worker.org.gradle.process.internal.worker.child.BootstrapSecurityManager
+        at sun.misc.Launcher.<init>(Launcher.java:102)
+        at sun.misc.Launcher.<clinit>(Launcher.java:53)
+        at java.lang.ClassLoader.initSystemClassLoader(ClassLoader.java:1451)
+        at java.lang.ClassLoader.getSystemClassLoader(ClassLoader.java:1436)
+
+    :app:testDebugUnitTest FAILED
+
+This failure seems like an anomaly and does not repeat.  Instead, a second error occurs which is recurrent:
+
+    ...
+    :app:testDebugUnitTestobjc[15694]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/bin/java (0x10fc714c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x10fcfd4e0). One of the two will be used. Which one is undefined.
+
+    :app:jacocoTestReport
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.ant/0.7.8/org.jacoco.ant-0.7.8.pom
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.core/0.7.8/org.jacoco.core-0.7.8.pom
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.report/0.7.8/org.jacoco.report-0.7.8.pom
+    Download https://jcenter.bintray.com/org/ow2/asm/asm-debug-all/5.1/asm-debug-all-5.1.pom
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.core/0.7.8/org.jacoco.core-0.7.8.jar
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.ant/0.7.8/org.jacoco.ant-0.7.8.jar
+    Download https://jcenter.bintray.com/org/jacoco/org.jacoco.report/0.7.8/org.jacoco.report-0.7.8.jar
+    Download https://jcenter.bintray.com/org/ow2/asm/asm-debug-all/5.1/asm-debug-all-5.1.jar
+    :app:jacocoTestReport FAILED
+
+    FAILURE: Build failed with an exception.
+
+    * What went wrong:
+    Execution failed for task ':app:jacocoTestReport'.
+    > Unable to read execution data file /Users/pmr/Projects/acc/app/build/outputs/code-coverage/connected/Nexus 6 - 7.0-coverage.ec
+
+And this is where things currently stand. The burning questions are:
+
+1) Which module owns this bug: Gradle, Jacoco, Android Gradle Plugin?
+
+I cast my vote for the latter.
+
+2) Is there a workaround to be had?
+
+Not that I can find ... yet.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,13 +30,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.android.support:design:26.1.0'
-    testCompile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:3.0.1', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support:design:26.1.0'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
     ext.kotlin_version = '1.1.51'
     repositories {
-        maven { url "https://maven.google.com" }
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -17,7 +17,7 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url "https://maven.google.com" }
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit uses the first release candidate for version 3.0.0 of the Android Gradle plugin and version 4.1 of Gradle.  It illustrates the current problem in trying to merge unit test and connected test code coverage results.

<h1>File changes:</h1>

modified:   README.md

- Summary: update to reflect observed results.

modified:   app/build.gradle

- Summary: update the compile -> implementation keyword change.

modified:   build.gradle

- Summary: update to use the google() repo and the 3.0.0-rc1 plugin.

modified:   gradle/wrapper/gradle-wrapper.properties

- Summary: update to use Gradle 4.1